### PR TITLE
fixes typo

### DIFF
--- a/rconsocket.go
+++ b/rconsocket.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type rconSocket struct {

--- a/samples/rcon.go
+++ b/samples/rcon.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/kidoman/go-steam"
 )
 

--- a/samples/udp.go
+++ b/samples/udp.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/kidoman/go-steam"
 )
 

--- a/server.go
+++ b/server.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	logrus "github.com/Sirupsen/logrus"
+	logrus "github.com/sirupsen/logrus"
 )
 
 type DialFn func(network, address string) (net.Conn, error)


### PR DESCRIPTION
I wasn't able to install the lib with `go get` with errors mentioned in #6. This PR, although a "real open-source contribution", fixes that error.